### PR TITLE
Incorrect caller information if app is invoked via 'go run'

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -52,7 +52,7 @@ func GetLogrusCaller() *stack.FrameInfo {
 		pc := uintptr(frames[idx]) - 1
 		f := runtime.FuncForPC(pc)
 		funcName := f.Name()
-		if strings.HasPrefix(strings.ToLower(funcName), "github.com/sirupsen") {
+		if strings.Contains(strings.ToLower(funcName), "github.com/sirupsen") {
 			continue
 		}
 		filePath, lineNo := f.FileLine(pc)


### PR DESCRIPTION
## Purpose
Incorrect function calls and line number information is logged if the app is invoked using `go run`

## Implementation
* Changed `string.HasPrefix` to `string.Contains` when searching for `github.com/sirupsen`