### PR TITLE
Now scrubbing auth headers from logged request structs

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -30,8 +30,13 @@ func ExpandNested(key string, value interface{}, dest map[string]interface{}) {
 
 // Given a *http.Request return a map with detailed information about the request
 func RequestToMap(req *http.Request) map[string]interface{} {
+	// Scrub auth information
+	headers := req.Header
+	headers.Del("Authorization")
+	headers.Del("Cookie")
+
 	return map[string]interface{}{
-		"headers":   req.Header,
+		"headers":   headers,
 		"ip":        req.RemoteAddr,
 		"method":    req.Method,
 		"params":    req.Form,

--- a/common/log_record.go
+++ b/common/log_record.go
@@ -99,6 +99,11 @@ func (r *LogRecord) FromFields(fields logrus.Fields) {
 				r.FileName = v
 				continue
 			}
+		case "category":
+			if v, ok := v.(string); ok {
+				r.Category = v
+				continue
+			}
 		}
 		ExpandNested(k, v, r.Context)
 	}


### PR DESCRIPTION
## Purpose
logrus hooks should not logging basic auth information

## Implemention
* Remove `Authorization` header from logged headers
