### PR TITLE
Now sending params and headers as params-json and headers-json

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -2,19 +2,17 @@ package common_test
 
 import (
 	"bytes"
-	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
-	. "gopkg.in/check.v1"
 	"github.com/mailgun/logrus-hooks/common"
+	. "gopkg.in/check.v1"
 )
 
 func TestCommon(t *testing.T) { TestingT(t) }
 
-type CommonTestSuite struct {}
+type CommonTestSuite struct{}
 
 var _ = Suite(&CommonTestSuite{})
 
@@ -56,10 +54,23 @@ func (s *CommonTestSuite) TestRequestToMap(c *C) {
 
 	result := common.RequestToMap(req)
 
-	c.Assert(result["headers"], DeepEquals, http.Header{"User-Agent": []string{"test-agent"}})
+	c.Assert(result["headers-json"], Equals, ""+
+		"{\n"+
+		"  \"User-Agent\": [\n"+
+		"    \"test-agent\"\n"+
+		"  ]\n"+
+		"}")
 	c.Assert(result["method"], Equals, "POST")
 	c.Assert(result["ip"], Equals, "192.0.2.1:1234")
-	c.Assert(result["params"], DeepEquals, url.Values{"param2": []string{"2"}, "param1": []string{"1"}})
+	c.Assert(result["params-json"], Equals, ""+
+		"{\n"+
+		"  \"param1\": [\n"+
+		"    \"1\"\n"+
+		"  ],\n"+
+		"  \"param2\": [\n"+
+		"    \"2\"\n"+
+		"  ]\n"+
+		"}")
 	c.Assert(result["size"], Equals, int64(4))
 	c.Assert(result["url"], Equals, "http://example.com?param1=1&param2=2")
 	c.Assert(result["useragent"], Equals, "test-agent")

--- a/kafkahook/kafkahook_test.go
+++ b/kafkahook/kafkahook_test.go
@@ -119,10 +119,23 @@ func (s *KafkaHookTests) TestKafkaHookRequest(c *C) {
 	c.Assert(resp["logLevel"], Equals, "ERROR")
 
 	http := resp["context"].(map[string]interface{})["http"].(map[string]interface{})
-	c.Assert(http["headers"], DeepEquals, map[string]interface{}{"User-Agent": []interface{}{"test-agent"}})
+	c.Assert(http["headers-json"], Equals, ""+
+		"{\n"+
+		"  \"User-Agent\": [\n"+
+		"    \"test-agent\"\n"+
+		"  ]\n"+
+		"}")
 	c.Assert(http["method"], DeepEquals, "POST")
 	c.Assert(http["ip"], Equals, "192.0.2.1:1234")
-	c.Assert(http["params"], DeepEquals, map[string]interface{}{"param1": []interface{}{"1"}, "param2": []interface{}{"2"}})
+	c.Assert(http["params-json"], Equals, ""+
+		"{\n"+
+		"  \"param1\": [\n"+
+		"    \"1\"\n"+
+		"  ],\n"+
+		"  \"param2\": [\n"+
+		"    \"2\"\n"+
+		"  ]\n"+
+		"}")
 	c.Assert(http["size"], Equals, float64(4))
 	c.Assert(http["url"], Equals, "http://example.com?param1=1&param2=2")
 	c.Assert(http["useragent"], Equals, "test-agent")
@@ -136,7 +149,7 @@ func (s *KafkaHookTests) TestFromErr(c *C) {
 
 	req := GetMsg(s.producer)
 	c.Assert(path.Base(req["filename"].(string)), Equals, "kafkahook_test.go")
-	c.Assert(req["lineno"], Equals, float64(133))
+	c.Assert(req["lineno"], Equals, float64(146))
 	c.Assert(req["funcName"], Equals, "TestFromErr()")
 	c.Assert(req["excType"], Equals, "*errors.fundamental")
 	c.Assert(req["excValue"], Equals, "bar: foo")

--- a/udploghook/udploghook_test.go
+++ b/udploghook/udploghook_test.go
@@ -112,10 +112,23 @@ func (s *UDPLogHookTests) TestUDPHookRequest(c *C) {
 	c.Assert(resp["logLevel"], Equals, "ERROR")
 
 	http := resp["context"].(map[string]interface{})["http"].(map[string]interface{})
-	c.Assert(http["headers"], DeepEquals, map[string]interface{}{"User-Agent": []interface{}{"test-agent"}})
+	c.Assert(http["headers-json"], Equals, ""+
+		"{\n"+
+		"  \"User-Agent\": [\n"+
+		"    \"test-agent\"\n"+
+		"  ]\n"+
+		"}")
 	c.Assert(http["method"], DeepEquals, "POST")
 	c.Assert(http["ip"], Equals, "192.0.2.1:1234")
-	c.Assert(http["params"], DeepEquals, map[string]interface{}{"param1": []interface{}{"1"}, "param2": []interface{}{"2"}})
+	c.Assert(http["params-json"], Equals, ""+
+		"{\n"+
+		"  \"param1\": [\n"+
+		"    \"1\"\n"+
+		"  ],\n"+
+		"  \"param2\": [\n"+
+		"    \"2\"\n"+
+		"  ]\n"+
+		"}")
 	c.Assert(http["size"], Equals, float64(4))
 	c.Assert(http["url"], Equals, "http://example.com?param1=1&param2=2")
 	c.Assert(http["useragent"], Equals, "test-agent")
@@ -129,12 +142,12 @@ func (s *UDPLogHookTests) TestFromErr(c *C) {
 
 	req := s.server.GetRequest()
 	c.Assert(path.Base(req["filename"].(string)), Equals, "udploghook_test.go")
-	c.Assert(req["lineno"], Equals, float64(126))
+	c.Assert(req["lineno"], Equals, float64(139))
 	c.Assert(req["funcName"], Equals, "TestFromErr()")
 	c.Assert(req["excType"], Equals, "*errors.fundamental")
 	c.Assert(req["excValue"], Equals, "bar: foo")
 	c.Assert(strings.Contains(req["excText"].(string), "(*UDPLogHookTests).TestFromErr"), Equals, true)
-	c.Assert(strings.Contains(req["excText"].(string), "github.com/mailgun/logrus-hooks/udploghook/udploghook_test.go:125"), Equals, true)
+	c.Assert(strings.Contains(req["excText"].(string), "github.com/mailgun/logrus-hooks/udploghook/udploghook_test.go:139"), Equals, true)
 }
 
 func (s *UDPLogHookTests) TestTIDAsString(c *C) {


### PR DESCRIPTION
## Purpose
* Send params as params-json and encodes the params as json
* Send headers as headers-json
* Fixed duplicate expand nested issue with http.Request object