### PR TITLE
Add level filter hook

### DIFF
--- a/cmd/kafka-hook/main.go
+++ b/cmd/kafka-hook/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/Shopify/sarama"
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/logrus-hooks/common"
 	"github.com/mailgun/logrus-hooks/kafkahook"
+	"github.com/sirupsen/logrus"
 	"github.com/thrawn01/args"
 )
 

--- a/cmd/udplog/main.go
+++ b/cmd/udplog/main.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/logrus-hooks/common"
 	"github.com/mailgun/logrus-hooks/udploghook"
+	"github.com/sirupsen/logrus"
 	"github.com/thrawn01/args"
 )
 

--- a/common/common.go
+++ b/common/common.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/holster/stack"
+	"github.com/sirupsen/logrus"
 )
 
 func ExpandNested(key string, value interface{}, dest map[string]interface{}) {

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/logrus-hooks/common"
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 

--- a/common/log_record.go
+++ b/common/log_record.go
@@ -40,6 +40,8 @@ func (r *LogRecord) FromFields(fields logrus.Fields) {
 	r.Context = make(map[string]interface{})
 	for k, v := range fields {
 		switch k {
+		// logrus.WithError adds a field with name error.
+		case "error": fallthrough
 		case "err":
 			// Record details of the error
 			if v, ok := v.(error); ok {

--- a/common/log_record.go
+++ b/common/log_record.go
@@ -3,9 +3,9 @@ package common
 import (
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/holster/errors"
 	"github.com/mailgun/holster/stack"
+	"github.com/sirupsen/logrus"
 )
 
 type Number float64

--- a/kafkahook/README.md
+++ b/kafkahook/README.md
@@ -6,7 +6,7 @@ A Logrus Hook for sending log info to [Kafka](https://kafka.apache.org)
 # Usage
 ```go
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/mailgun/logrus-hooks/kafkahook"
 )
 

--- a/kafkahook/kafkahook.go
+++ b/kafkahook/kafkahook.go
@@ -139,14 +139,7 @@ func (h *KafkaHook) SendIO(input io.Reader) error {
 
 // Levels returns the available logging levels.
 func (h *KafkaHook) Levels() []logrus.Level {
-	return []logrus.Level{
-		logrus.PanicLevel,
-		logrus.FatalLevel,
-		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
-	}
+	return logrus.AllLevels
 }
 
 func (h *KafkaHook) SetDebug(set bool) {

--- a/kafkahook/kafkahook.go
+++ b/kafkahook/kafkahook.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/holster/errors"
 	"github.com/mailgun/holster/stack"
 	"github.com/mailgun/logrus-hooks/common"
 	"github.com/mailru/easyjson/jwriter"
+	"github.com/sirupsen/logrus"
 )
 
 type KafkaHook struct {

--- a/kafkahook/kafkahook_test.go
+++ b/kafkahook/kafkahook_test.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/Shopify/sarama/mocks"
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/holster/errors"
 	"github.com/mailgun/logrus-hooks/common"
 	"github.com/mailgun/logrus-hooks/kafkahook"
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 

--- a/levelfilter/levelfilter.go
+++ b/levelfilter/levelfilter.go
@@ -1,0 +1,30 @@
+package levelfilter
+
+import "github.com/sirupsen/logrus"
+
+type LevelFilter struct {
+	hook logrus.Hook
+	levels []logrus.Level
+}
+
+func New(hook logrus.Hook, level logrus.Level) *LevelFilter {
+	levels := make([]logrus.Level, 0, len(logrus.AllLevels))
+	for _, l := range hook.Levels() {
+		if l <= level {
+			levels = append(levels, l)
+		}
+	}
+
+	return &LevelFilter{
+		hook: hook,
+		levels: levels,
+	}
+}
+
+func (lf *LevelFilter) Levels() []logrus.Level {
+	return lf.levels
+}
+
+func (lf *LevelFilter) Fire(entry *logrus.Entry) error {
+	return lf.hook.Fire(entry)
+}

--- a/levelfilter/levelfilter_test.go
+++ b/levelfilter/levelfilter_test.go
@@ -1,0 +1,104 @@
+package levelfilter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type LevelFilterSuite struct{}
+
+var _ = Suite(&LevelFilterSuite{})
+
+// Only levels with higher or the same severity are advertised by a level
+// filtering hook.
+func (s *LevelFilterSuite) TestLevels(c *C) {
+	for i, tc := range []struct {
+		original []logrus.Level
+		level    logrus.Level
+		filtered []logrus.Level
+	}{
+		0: {
+		original: logrus.AllLevels,
+		level:    logrus.PanicLevel,
+		filtered: []logrus.Level{logrus.PanicLevel},
+	},
+		1: {
+		original: logrus.AllLevels,
+		level:    logrus.FatalLevel,
+		filtered: []logrus.Level{logrus.PanicLevel, logrus.FatalLevel},
+	}, 2: {
+		original: logrus.AllLevels,
+		level:    logrus.ErrorLevel,
+		filtered: []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel},
+	}, 3: {
+		original: logrus.AllLevels,
+		level:    logrus.WarnLevel,
+		filtered: []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel},
+	}, 4: {
+		original: logrus.AllLevels,
+		level:    logrus.InfoLevel,
+		filtered: []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel, logrus.InfoLevel},
+	}, 5: {
+		original: logrus.AllLevels,
+		level:    logrus.DebugLevel,
+		filtered: []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel, logrus.InfoLevel, logrus.DebugLevel},
+	}, 6: {
+		// Original missing levels stay missing when filtered.
+		original: []logrus.Level{logrus.PanicLevel, logrus.WarnLevel, logrus.InfoLevel, logrus.DebugLevel},
+		level:    logrus.InfoLevel,
+		filtered: []logrus.Level{logrus.PanicLevel, logrus.WarnLevel, logrus.InfoLevel},
+	}, 7: {
+		// It is ok to specify a level missing in the original list for filtering.
+		original: []logrus.Level{logrus.PanicLevel, logrus.WarnLevel, logrus.DebugLevel},
+		level:    logrus.InfoLevel,
+		filtered: []logrus.Level{logrus.PanicLevel, logrus.WarnLevel},
+	}} {
+		fmt.Printf("Test case #%d", i)
+
+		fakeHook := newFakeHook(tc.original)
+		lf := New(fakeHook, tc.level)
+
+		c.Assert(lf.Levels(), DeepEquals, tc.filtered)
+	}
+}
+
+// Fire calls to a level filter hook are forwarded to the underlying hook.
+func (s *LevelFilterSuite) TestFire(c *C) {
+	fakeHook := newFakeHook(logrus.AllLevels)
+	lf := New(fakeHook, logrus.PanicLevel)
+	c.Assert(fakeHook.entries, DeepEquals, []*logrus.Entry(nil))
+
+	// When
+	e1 := &logrus.Entry{Message: "1"}
+	lf.Fire(e1)
+	e2 := &logrus.Entry{Message: "2"}
+	lf.Fire(e2)
+	e3 := &logrus.Entry{Message: "3"}
+	lf.Fire(e3)
+
+	// Then
+	c.Assert(fakeHook.entries, DeepEquals, []*logrus.Entry{e1, e2, e3})
+}
+
+type fakeHook struct {
+	levels []logrus.Level
+	entries []*logrus.Entry
+}
+
+func newFakeHook(levels []logrus.Level) *fakeHook {
+	return &fakeHook{levels: levels}
+}
+
+func (h *fakeHook) Levels() []logrus.Level {
+	return h.levels
+}
+
+func (h *fakeHook) Fire(entry *logrus.Entry) error {
+	h.entries = append(h.entries, entry)
+	return nil
+}

--- a/udploghook/README.md
+++ b/udploghook/README.md
@@ -6,7 +6,7 @@ A Logrus Hook for sending log info to [UDPLog](https://github.com/mochi/udplog)
 # Usage
 ```go
 import (
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "github.com/mailgun/logrus-hooks/udploghook"
 )
 

--- a/udploghook/udploghook.go
+++ b/udploghook/udploghook.go
@@ -121,14 +121,7 @@ func (h *UDPHook) SendIO(input io.Reader) error {
 
 // Levels returns the available logging levels.
 func (h *UDPHook) Levels() []logrus.Level {
-	return []logrus.Level{
-		logrus.PanicLevel,
-		logrus.FatalLevel,
-		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
-	}
+	return logrus.AllLevels
 }
 
 func (h *UDPHook) SetDebug(set bool) {

--- a/udploghook/udploghook.go
+++ b/udploghook/udploghook.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/holster/stack"
 	"github.com/mailgun/logrus-hooks/common"
 	"github.com/mailru/easyjson/jwriter"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type UDPHook struct {

--- a/udploghook/udploghook_test.go
+++ b/udploghook/udploghook_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mailgun/holster/errors"
 	"github.com/mailgun/logrus-hooks/common"
 	"github.com/mailgun/logrus-hooks/udploghook"
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 


### PR DESCRIPTION
### Problem

In logrus logging level cannot be specified on per hook basis. E.g. there is no way to limit the syslog hook to the INFO level and the Kafka hook to the WARN level. 

### Solution

LevelFilter can wrap around any hook to define the log level a hook is registered for

### Misc

Account for name change: `Sirupsen/logrus` was renamed to `sirupsen/logrus`
